### PR TITLE
Github actions test environment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Build antikythera-agent
         run: cd ../antikythera-agent && MAVEN_OPTS="--add-opens java.base/java.util.stream=ALL-UNNAMED --add-exports java.base/java.util.stream=ALL-UNNAMED" mvn clean install
 
+      - name: Resolve antikythera-test-helper dependencies
+        run: cd ../antikythera-test-helper && MAVEN_OPTS="--add-opens java.base/java.util.stream=ALL-UNNAMED --add-exports java.base/java.util.stream=ALL-UNNAMED" mvn -q -DskipTests dependency:go-offline
+
       - name: Build antikythera-sample-project
         run: cd ../antikythera-sample-project && MAVEN_OPTS="--add-opens java.base/java.util.stream=ALL-UNNAMED --add-exports java.base/java.util.stream=ALL-UNNAMED" mvn clean install
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a workflow step to resolve `antikythera-test-helper` dependencies to fix `TestAKBuddy` failures in GitHub Actions.

The `TestAKBuddy` failures were due to `ModelMapper` being a dependency of `antikythera-test-helper` which was not being resolved in CI, causing `ModelMapper` to be absent during test execution. This step ensures `modelmapper-3.0.0.jar` is available in the Maven local repository for tests.

<div><a href="https://cursor.com/agents/bc-e51dbe7c-6ac7-442a-b8e5-5d3dbdd03e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51dbe7c-6ac7-442a-b8e5-5d3dbdd03e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process efficiency for internal testing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->